### PR TITLE
fix: XpathDirective did not work with double quotes

### DIFF
--- a/src/Yaapii.Xml.Xembly/Directive/XpathDirective.cs
+++ b/src/Yaapii.Xml.Xembly/Directive/XpathDirective.cs
@@ -77,7 +77,7 @@ namespace Yaapii.Xml.Xembly
         public ICursor Exec(XmlNode dom, ICursor cursor, IStack stack)
         {
             IEnumerable<XmlNode> targets;
-            string query = this._expr.Raw();
+            string query = SingleQuoted(this._expr.Raw());
 
             // CSA: Not working in this version. Use only traditional function.
             //if (ROOT_ONLY.IsMatch(query))
@@ -125,6 +125,11 @@ namespace Yaapii.Xml.Xembly
             }
 
             return targets;
+        }
+
+        private string SingleQuoted(string arg)
+        {
+            return arg.Replace("\"", "'");
         }
 
         /// <summary>

--- a/src/Yaapii.Xml.Xembly/Xembler.cs
+++ b/src/Yaapii.Xml.Xembly/Xembler.cs
@@ -129,10 +129,10 @@ namespace Yaapii.Xml.Xembly
                     throw new ImpossibleModificationException(
                         new FormattedText("directive {0}: {1}", pos, dir).AsString());
                 }
-                catch (Exception) //TODO: Original catches DOMException. We don't have that. But do we have something similar?
+                catch (Exception ex) //TODO: Original catches DOMException. We don't have that. But do we have something similar?
                 {
                     throw new ImpossibleModificationException(
-                        new FormattedText("Exception at dir {0}: {1}", pos, dir).AsString());
+                        new FormattedText("Exception at dir {0}: {1} ({2})", pos, dir, ex.Message).AsString());
                 }
                 ++pos;
             }

--- a/tests/Yaapii.Xml.Xembly.Tests/Directive/DirectivesTest.cs
+++ b/tests/Yaapii.Xml.Xembly.Tests/Directive/DirectivesTest.cs
@@ -277,11 +277,14 @@ namespace Yaapii.Xml.Xembly.Directive.Tests
         {
             IEnumerable<IDirective> dirs =
                 new Directives(
-                    "ADD 'yummy directive';"
-            );
+                    "ADD 'root'; ADD 'something'; SET 'Teststring';" +
+                    "XPATH '/root/something[contains(.,\"Teststring\")]'; UP; " +
+                    "ADD 'yummydirective';");
+
+            new Xembler(dirs).Apply(new XmlDocument());
 
             Assert.True(
-                new Yaapii.Atoms.Enumerable.LengthOf(dirs).Value() == 1);
+                new Yaapii.Atoms.Enumerable.LengthOf(dirs).Value() == 6);
         }
 
 

--- a/tests/Yaapii.Xml.Xembly.Tests/Directive/XpathDirectiveTests.cs
+++ b/tests/Yaapii.Xml.Xembly.Tests/Directive/XpathDirectiveTests.cs
@@ -96,6 +96,23 @@ namespace Yaapii.Xml.Xembly.Tests.Directive
                     new DomStack()));
         }
 
+        [Fact]
+        public void WorksWithDoubleQuotes()
+        {
+            var dom = new XmlDocument();
+
+            new Xembler(new Directives().Add("Tags").Add("Tag").Set("Transient")).Apply(dom);
+            
+
+            Assert.NotEmpty(
+                new XpathDirective(
+                    "//Tag[contains(.,'Transient')]").Exec(
+                    dom,
+                    new DomCursor(
+                        new Yaapii.Atoms.Enumerable.EnumerableOf<XmlNode>(dom)),
+                    new DomStack()));
+        }
+
         /// <summary>
         /// XpathDirective can find root in cloned document.
         /// </summary>


### PR DESCRIPTION
closes #84

### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

### What is the current behavior? (You can also link to an open issue here)
#84 

### What is the new behavior?
We can use double quotes in XpathDirective's query string

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

###  Other information